### PR TITLE
README: requires Ruby 2.1 (for optional keyword args)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A small collection of utilies for [logfmt](http://brandur.org/logfmt) processing
 gem install hutils
 ```
 
+Requires Ruby 2.1.0 or later.
+
 ## Utilities
 
 ### lcut


### PR DESCRIPTION
Document Ruby 2.1.0+ requirement (due to optional keyword arguments). In case anyone else searches for the exception traceback, here it is:

```
/path/to/gems/hutils-0.2.0/lib/hutils.rb:4:in `require_relative': /path/to/gems/2.0.0/gems/hutils-0.2.0/lib/hutils/text_visualizer.rb:9: syntax error, unexpected ',' (SyntaxError)
      def initialize(colors:, compact:, highlights:, out:)
                             ^
```
