### PR TITLE
Fix lviz opts

### DIFF
--- a/bin/lviz
+++ b/bin/lviz
@@ -22,10 +22,8 @@ opts = OptionParser.new do |opts|
   opts.banner = "Usage: lviz [options] <file> ..."
   opts.on("--compact", "Compact display") { |c| compact = c }
   opts.on("-h", "--help", "Show this help string") { |h|
-    if h
-      puts(opts.help)
-      exit(0)
-    end
+    puts(opts.help)
+    exit(0)
   }
   opts.on("--highlights", "Keys to highlight (comma separated)") { |h|
     highlights = h.split(",") rescue []

--- a/bin/lviz
+++ b/bin/lviz
@@ -25,11 +25,11 @@ opts = OptionParser.new do |opts|
     puts(opts.help)
     exit(0)
   }
-  opts.on("--highlights", "Keys to highlight (comma separated)") { |h|
-    highlights = h.split(",") rescue []
+  opts.on("--highlights ...", Array, "Keys to highlight (comma separated)") { |h|
+    highlights = h
   }
-  opts.on("--ignore", "Keys to ignore (comma separated)") { |i|
-    ignore = i.split(",") rescue []
+  opts.on("--ignore ...", Array, "Keys to ignore (comma separated)") { |i|
+    ignore = i
   }
   opts.on("-i", "--interactive", "Interactive mode") { |i| interactive = i }
   opts.on("--no-color", "Disable colors") { |c| colors = false }


### PR DESCRIPTION
This fixes the `OptionParser` in `lviz` to remove the list values from `ARGV`. Without this, `ARGF.read` was failing if an `--ignore` or `--highlight` option was set, as is was trying to find the value as a file, which does not exist. It also simplifies the logic by using the built in array parser. 
